### PR TITLE
Write timing output into separate files and use more levels

### DIFF
--- a/tests/cook_mf.prm
+++ b/tests/cook_mf.prm
@@ -11,7 +11,9 @@ end
 
 subsection Geometry
   # Number of elements per long edge of the beam
-  set Elements per edge  = 32
+  set Elements per edge  = 2
+ 
+  set Global refinement  = 5
 
   # Global grid scaling factor
   set Grid scale         = 1e-3

--- a/tests/cook_mf_gmg.prm
+++ b/tests/cook_mf_gmg.prm
@@ -11,9 +11,9 @@ end
 
 subsection Geometry
   # Number of elements per long edge of the beam
-  set Elements per edge  = 8
+  set Elements per edge  = 2
 
-  set Global refinement  = 2
+  set Global refinement  = 5
 
   # Global grid scaling factor
   set Grid scale         = 1e-3


### PR DESCRIPTION
This PR writes the timings for each test in a separate `timings.txt` files and provides more detailed information for the GMG run. Doing so revealed that most of the time was spent in the coarse solver.
Choosing level 0 as coarse as possible improves results significantly.