### PR TITLE
add more asserts

### DIFF
--- a/include/mf_nh_operator.h
+++ b/include/mf_nh_operator.h
@@ -427,6 +427,15 @@ using namespace dealii;
                              FEEvaluation<dim,fe_degree,n_q_points_1d,dim,number> &phi_reference,
                              const unsigned int cell) const
   {
+    // make sure both MatrixFree objects use the same cells
+    AssertDimension(data_current->n_components_filled(cell), data_reference->n_components_filled(cell));
+    for (unsigned int i = 0; i < data_current->n_components_filled(cell); ++i)
+      Assert (data_current->get_cell_iterator(cell,i) == data_reference->get_cell_iterator(cell,i),
+              ExcMessage("Cell block " + std::to_string(cell) +
+                         " element " + std::to_string(i) +
+                         " does not match between two MatrixFree objects."
+                         ));
+
     typedef VectorizedArray<number> NumberType;
     static constexpr number dim_f = dim;
     static constexpr number two_over_dim = 2.0/dim;


### PR DESCRIPTION
There seem to be a bug somewhere, maybe in deal.II, I will investigate further but create this WIP PR right away in case either of you have some hints...


`cook.debug` test works fine in 2D, but `cook_3d_lin` fails miserably:
```
2:     std::abs(JxW_scale[i] * det_F[i] - 1.) < 1000.*std::numeric_limits<number>::epsilon()
2: Additional information:
2:     4: 1.000000!=1.050382 0.047965
```
which means that `det_F` is exactly `1` but the ratio between `JxW` with and without mapping isn't. This happens at the first (after `0-th`, to avoid confusion) Newton-Raphson iteration, so it's `det_F` which looks strange here... The error is during GMG setup https://github.com/davydden/large-strain-matrix-free/blob/master/include/mf_elasticity.h#L1076  (computation of diagonal).

 