### PR TITLE
Minor code adjustment

### DIFF
--- a/include/mf_elasticity.h
+++ b/include/mf_elasticity.h
@@ -2127,12 +2127,15 @@ namespace Cook_Membrane
         // update total solution prior to assembly
         set_total_solution();
 
-        // setup matrix-free part:
-        setup_matrix_free(newton_iteration);
-
         // now ready to go-on and assmble linearized problem around solution_n +
         // solution_delta for this iteration.
         assemble_system();
+
+        if (check_convergence(newton_iteration))
+          break;
+
+        // setup matrix-free part:
+        setup_matrix_free(newton_iteration);
 
         // check vmult of matrix-based and matrix-free for a random vector:
         {
@@ -2283,9 +2286,6 @@ namespace Cook_Membrane
             }
 #endif
         }
-
-        if (check_convergence(newton_iteration))
-          break;
 
         const std::tuple<unsigned int, double, double> lin_solver_output =
           solve_linear_system(newton_update, newton_update_trilinos);


### PR DESCRIPTION
only the last commit actually changes a bit logic, but since [assemble_system()](https://github.com/davydden/large-strain-matrix-free/blob/master/include/mf_elasticity.h#L2430-L2632) does not need MF/GMG to be ready, that should be ok to do.

All tests pass for me locally on macOS for all commits.