### PR TITLE
Split up setup of mg_mf_data_current

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,15 +25,12 @@ jobs:
       matrix:
         build_type: ["Release"]
         dealii_version: ["master", "v9.3.0", "v9.2.0"]
-    
+
     container:
       image: dealii/dealii:${{ matrix.dealii_version }}-focal
+      options: --user root
 
     steps:
-      - name: Setup
-        run: |
-          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-          
       - uses: actions/checkout@v2
 
       - name: Compile
@@ -42,4 +39,3 @@ jobs:
           cd build
           cmake ../ -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           make -j${{ env.COMPILE_JOBS }}
-          

--- a/include/mf_elasticity.h
+++ b/include/mf_elasticity.h
@@ -2434,7 +2434,7 @@ namespace Cook_Membrane
         Tensor<1, dim> displacement;
         unsigned int   found = 0;
 
-#if DEAL_II_VERSION_GTE(9, 4, 0)
+#if DEAL_II_VERSION_GTE(9, 3, 0)
         const MappingQ<dim> mapping(degree);
         const auto          cell_point =
           GridTools::find_active_cell_around_point(mapping,

--- a/include/mf_nh_operator.h
+++ b/include/mf_nh_operator.h
@@ -689,7 +689,10 @@ NeoHookOperator<dim, fe_degree, n_q_points_1d, number>::vmult_add(
 
   // 3. communicate results with MPI
   if (mask & MFMask::MPI)
-    dst.compress(VectorOperation::add);
+    {
+      dst.compress(VectorOperation::add);
+      src.zero_out_ghosts();
+    }
 
   // 4. constraints
   if (mask & MFMask::RW)


### PR DESCRIPTION
This PR refactors the setup of `mg_mf_data_current` and of the transfer operator. The sequence is now:
1) setup `mg_mf_data_reference`
2) setup transfer operator, using  `mg_mf_data_reference`
3) interpolate `mg_solution_total`
4) setup `mg_mf_data_current`

This is the same sequence that can be used for GC.

references #105

depends on #104